### PR TITLE
Fix default on_error callback arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ require 'forked'
 
 process_manager = Forked::ProcessManager.new(logger: Logger.new(STDOUT), process_timeout: 5)
 
-process_manager.fork('monitor', on_error: ->(e) { puts e.inspect }) do
+process_manager.fork('monitor', on_error: ->(e, tries) { puts e.inspect }) do
   loop do
     puts "hi"
     sleep 1

--- a/lib/forked/process_manager.rb
+++ b/lib/forked/process_manager.rb
@@ -3,13 +3,15 @@ require 'timeout'
 
 module Forked
   class ProcessManager
+    ON_ERROR = -> (e, tries) { }
+
     def initialize(process_timeout: 5, logger: Logger.new(STDOUT))
       @process_timeout = process_timeout
       @workers = {}
       @logger = logger
     end
 
-    def fork(name = nil, retry_strategy: ::Forked::RetryStrategies::ExponentialBackoff, on_error: -> (e) {}, &block)
+    def fork(name = nil, retry_strategy: ::Forked::RetryStrategies::ExponentialBackoff, on_error: ON_ERROR, &block)
       worker = Worker.new(name, retry_strategy, on_error, block)
       fork_worker(worker)
     end

--- a/spec/process_manager_spec.rb
+++ b/spec/process_manager_spec.rb
@@ -67,8 +67,7 @@ RSpec.describe Forked::ProcessManager do
   end
 
   describe Forked::RetryStrategies::Always do
-    let(:on_error) { double(call: true) }
-    subject(:always) { described_class.new(logger: logger, on_error: on_error) }
+    subject(:always) { described_class.new(logger: logger, on_error: Forked::ProcessManager::ON_ERROR) }
 
     it 'raises' do
       expect {
@@ -80,8 +79,7 @@ RSpec.describe Forked::ProcessManager do
   end
 
   describe Forked::RetryStrategies::ExponentialBackoff do
-    let(:on_error) { double(call: true) }
-    subject(:always) { described_class.new(logger: logger, on_error: on_error) }
+    subject(:always) { described_class.new(logger: logger, on_error: Forked::ProcessManager::ON_ERROR) }
 
     it 'raises' do
       expect {


### PR DESCRIPTION
I've moved it into a constant so it can be reused by the specs to ensure the different retry strategies work with the default callback.