### PR TITLE
Update on_error callback to include a tries parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ require 'forked'
 
 process_manager = Forked::ProcessManager.new(logger: Logger.new(STDOUT), process_timeout: 5)
 
-process_manager.fork('monitor', on_error: ->(e) { puts e.inspect }) do
+process_manager.fork('monitor', on_error: ->(e, tries) { puts e.inspect }) do
   loop do
     puts "hi"
     sleep 1

--- a/lib/forked/process_manager.rb
+++ b/lib/forked/process_manager.rb
@@ -9,7 +9,7 @@ module Forked
       @logger = logger
     end
 
-    def fork(name = nil, retry_strategy: ::Forked::RetryStrategies::ExponentialBackoff, on_error: -> (e) {}, &block)
+    def fork(name = nil, retry_strategy: ::Forked::RetryStrategies::ExponentialBackoff, on_error: -> (e, tries) {}, &block)
       worker = Worker.new(name, retry_strategy, on_error, block)
       fork_worker(worker)
     end


### PR DESCRIPTION
In https://github.com/envato/forked/blob/master/lib/forked/retry_strategies/exponential_backoff.rb#L18
it calls the on_error callback with two parameters:
  - the exception
  - tries

This PR updates the documentation and default on_error callback to
include the second `tries` parameter.