### PR TITLE
Add new retry strategy for continuous loop blocks

### DIFF
--- a/forked.gemspec
+++ b/forked.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/lib/forked.rb
+++ b/lib/forked.rb
@@ -2,6 +2,7 @@ require 'forked/version'
 require 'forked/worker'
 require 'forked/retry_strategies/always'
 require 'forked/retry_strategies/exponential_backoff'
+require 'forked/retry_strategies/exponential_backoff_with_limit'
 require 'forked/process_manager'
 require 'forked/with_graceful_shutdown'
 

--- a/lib/forked/retry_strategies/exponential_backoff_with_limit.rb
+++ b/lib/forked/retry_strategies/exponential_backoff_with_limit.rb
@@ -1,0 +1,33 @@
+module Forked
+  module RetryStrategies
+    class ExponentialBackoffWithLimit
+      def initialize(logger:, on_error:, backoff_factor: 2, limit: 8)
+        @logger = logger
+        @on_error = on_error
+        @backoff_factor = backoff_factor
+        @limit = 8
+      end
+
+      def run(ready_to_stop, &block)
+        tries = 0
+        begin
+          block.call
+        rescue => e
+          tries += 1
+
+          @logger.error("#{e.class} #{e.message}")
+          @on_error.call(e, tries)
+          raise if tries > @limit
+
+          sleep_seconds = @backoff_factor**tries
+          sleep_seconds.times do
+            ready_to_stop.call
+            sleep 1
+          end
+
+          retry
+        end
+      end
+    end
+  end
+end

--- a/lib/forked/retry_strategies/exponential_backoff_with_limit.rb
+++ b/lib/forked/retry_strategies/exponential_backoff_with_limit.rb
@@ -1,11 +1,11 @@
 module Forked
   module RetryStrategies
     class ExponentialBackoffWithLimit
-      def initialize(logger:, on_error:, backoff_factor: 2, limit: 8)
+      def initialize(logger:, on_error:, backoff_factor: 2, limit: nil)
         @logger = logger
         @on_error = on_error
         @backoff_factor = backoff_factor
-        @limit = 8
+        @limit = limit || 8
       end
 
       def run(ready_to_stop, &block)

--- a/lib/forked/version.rb
+++ b/lib/forked/version.rb
@@ -1,3 +1,3 @@
 module Forked
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/lib/forked/worker.rb
+++ b/lib/forked/worker.rb
@@ -1,4 +1,10 @@
 module Forked
-  class Worker < Struct.new(:name, :retry_strategy, :on_error, :block)
+  class Worker < Struct.new(
+    :name,
+    :retry_strategy,
+    :retry_backoff_limit,
+    :on_error,
+    :block,
+    keyword_init: true)
   end
 end

--- a/spec/process_manager_spec.rb
+++ b/spec/process_manager_spec.rb
@@ -43,6 +43,24 @@ RSpec.describe Forked::ProcessManager do
     t.exit
   end
 
+  context 'ExponentialBackoffWithLimit retry strategy' do
+    it 'accepts the ExponentialBackoffWithLimit' do
+      expect(Forked::RetryStrategies::ExponentialBackoffWithLimit)
+        .to receive(:new).with(hash_including(logger: logger)).and_call_original
+
+      pm = Forked::ProcessManager.new(logger: logger)
+      pm.fork(retry_strategy: Forked::RetryStrategies::ExponentialBackoffWithLimit) {  }
+    end
+
+    it 'accepts the ExponentialBackoffWithLimit with an optional backoff_limit parameter' do
+      expect(Forked::RetryStrategies::ExponentialBackoffWithLimit)
+        .to receive(:new).with(hash_including(logger: logger, limit: 10)).and_call_original
+
+      pm = Forked::ProcessManager.new(logger: logger)
+      pm.fork(retry_strategy: Forked::RetryStrategies::ExponentialBackoffWithLimit, retry_backoff_limit: 10) {  }
+    end
+  end
+
   context 'custom retry strategies' do
     let(:custom_retry) do
       Class.new do
@@ -79,16 +97,44 @@ RSpec.describe Forked::ProcessManager do
   end
 
   describe Forked::RetryStrategies::ExponentialBackoff do
-    subject(:always) { described_class.new(logger: logger, on_error: Forked::ProcessManager::ON_ERROR) }
+    subject(:exponential_backoff) { described_class.new(logger: logger, on_error: Forked::ProcessManager::ON_ERROR) }
 
-    it 'raises' do
+    it 'does not raise an error' do
       expect {
         i = 0
-        always.run(-> {}) do
+        exponential_backoff.run(-> {}) do
           i += 1
           raise 'boo' unless i > 1
         end
       }.to_not raise_error
+    end
+  end
+
+  describe Forked::RetryStrategies::ExponentialBackoffWithLimit do
+    before do
+      def exponential_backoff_with_limit.sleep(seconds); end
+    end
+
+    subject(:exponential_backoff_with_limit) { described_class.new(logger: logger, on_error: Forked::ProcessManager::ON_ERROR) }
+
+    it 'does not raise an error if backoff limit is not reached' do
+      expect {
+        i = 0
+        exponential_backoff_with_limit.run(-> {}) do
+          i += 1
+          raise 'boo' unless i > 1
+        end
+      }.to_not raise_error
+    end
+
+    it 'raises an error if backoff limit is reached' do
+      expect {
+        i = 0
+        exponential_backoff_with_limit.run(-> {}) do
+          i += 1
+          raise StandardError, 'boo'
+        end
+      }.to raise_error(StandardError, 'boo')
     end
   end
 end

--- a/spec/retry_strategies/exponential_backoff_with_limit_spec.rb
+++ b/spec/retry_strategies/exponential_backoff_with_limit_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe Forked::RetryStrategies::ExponentialBackoffWithLimit do
+  let(:ready_to_stop) { ->{} }
+  let(:logger) { instance_double(Logger, error: nil) }
+  let(:on_error) { instance_double(Proc, call: nil) }
+  let(:raise_error_on_first_try_block) do
+    tries = 0
+    proc do
+      if tries == 0
+        tries += 1
+        raise TestError
+      end
+      tries += 1
+      tries
+    end
+  end
+  subject(:exponential_backoff_with_limit) { described_class.new(logger: logger, on_error: on_error) }
+
+  before do
+    def exponential_backoff_with_limit.sleep(seconds); end
+  end
+
+  it 'returns the result of the block' do
+    return_value = exponential_backoff_with_limit.run(ready_to_stop) { 42 }
+    expect(return_value).to eq 42
+  end
+
+  it 'calls on_error on error then returns' do
+    return_value = exponential_backoff_with_limit.run(->{}) do
+      raise_error_on_first_try_block.call
+      42
+    end
+    expect(on_error).to have_received(:call).with(an_instance_of(TestError), 1)
+    expect(return_value).to eq 42
+  end
+
+  it 'logs the error' do
+    exponential_backoff_with_limit.run(->{}) { raise_error_on_first_try_block.call } rescue TestError
+    expect(logger).to have_received(:error)
+  end
+
+  it 'calls ready to stop each second interval' do
+    ready_to_stop = instance_double(Proc, call: nil)
+    exponential_backoff_with_limit.run(ready_to_stop) { raise_error_on_first_try_block.call }
+    expect(ready_to_stop).to have_received(:call).twice
+  end
+
+  it 'sleeps with exponential backoff' do
+    tries = 1
+    raise_twice_block = proc do
+      if tries < 3
+        tries += 1
+        raise TestError
+      end
+      tries += 1
+      tries
+    end
+
+    # 2 seconds first error, 4 seconds second error = sleep called 6 times
+    expect(exponential_backoff_with_limit).to receive(:sleep).with(1).exactly(6).times
+
+    exponential_backoff_with_limit.run(ready_to_stop) { raise_twice_block.call }
+  end
+
+  it 'limits the number of tries' do
+    start = 1
+    raise_10_times_block = proc do
+      (start..10).each do |position|
+        start = (position + 1) # starting position next time the block is called
+        raise TestError
+      end
+    end
+
+    # Loops 1-8: errors, 2**try seconds for each try
+    #   Back off for 2+4+8+16+32+64+128+256 seconds = sleep is called 510 times
+    # The 9th and 10th loop through the block is never called
+    # because the retries are limited by default to 8
+    expect(exponential_backoff_with_limit).to receive(:sleep).with(1).exactly(510).times
+
+    expect {
+      exponential_backoff_with_limit.run(ready_to_stop) { raise_10_times_block.call }
+    }.to raise_error TestError
+  end
+end


### PR DESCRIPTION
## Context

The `ExponentialBackoff` retry strategy is not behaving well with blocks that are running in an infinite loop.

This is the retry code for the strategy:

```
      def run(ready_to_stop, &block)
        tries = 0
        begin
          block.call
        rescue => e
          tries += 1
          sleep_seconds = @backoff_factor**tries
          @logger.error("#{e.class} #{e.message}")
          @on_error.call(e, tries)
          sleep_seconds.times do
            ready_to_stop.call
            sleep 1
          end
          retry
        end
      end
```

* If `block` is an infinite loop, it never actually exits the call unless there is an error.
* When an error is encountered, forked rescues it, sleeps for a number of seconds, then calls a `retry`.
* This means that only the call within `begin` -- so `block.call` -- is retried.
* Even if `block.call` succeeds for several turns around its loop, the loop is internal to the block.
* The process never gets out of the `begin` -> `rescue` -> `retry` block, so the number of `tries` is never reset.

**Example flow:**

1. `run` is called
1. `tries` starts at 0
1. `block.call` is called, succeeds for several turns within its loop, then encounters an error
1. `tries` increases to 1; sleeps for 2**1 seconds, then calls `retry`
1. `block.call` is called, succeeds for several turns within its loop, then encounters an error
1. `tries` increases to 1; sleeps for 2**2 seconds, then calls `retry`
1. `block.call` is called, succeeds for several turns within its loop, then encounters an error
1. `tries` increases to 1; sleeps for 2**3 seconds, then calls `retry`

With a process that runs long enough, encountering a few errors along the way, we could be left with a long backoff.

## Change

Add an `ExponentialBackoffWithLimit` retry strategy. When a retry limit is reached, the error bubbles up to the master process, like in the `Always` retry strategy. The master process will then restart the forked process, with the try count being reset.

I have set a retry limit of 8, which means an upper bound of 2**8=256 seconds=~4 minutes of sleep before the error bubbles up and the number of tries is reset.

## Discussions

We are using this logic on a [custom retry strategy in an actual running process](https://github.com/envato/content-warehouse-api/blob/master/app/processors/feed_consumer_helpers/exponential_backoff_with_limit_retry_strategy.rb) ([PR here](https://github.com/envato/content-warehouse-api/pull/93))but I think this retry_with_limit strategy is worth adding to forked since we can expect infinite loop blocks to be called within forked processes.

Will upgrade the version if this PR gets a ✅ 

cc @envato/content-warehouse-team 