### PR TITLE
Support ruby3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/lib/forked/process_manager.rb
+++ b/lib/forked/process_manager.rb
@@ -45,7 +45,7 @@ module Forked
     def fork_worker(worker)
       retry_params = { logger: @logger, on_error: worker.on_error }
       retry_params[:limit] = worker.retry_backoff_limit if worker.retry_strategy == RetryStrategies::ExponentialBackoffWithLimit
-      retry_strategy = worker.retry_strategy.new(retry_params)
+      retry_strategy = worker.retry_strategy.new(**retry_params)
 
       pid = Kernel.fork do
         WithGracefulShutdown.run(logger: @logger) do |ready_to_stop|


### PR DESCRIPTION
Ruby3 has removed automatically destructuring hashes into keyword args causing errors like:

```
wrong number of arguments (given 1, expected 0; required keywords: logger, on_error)
```

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

By being explicit with destucturing (splat) the keyword args while passing them in we can maintain support for ruby 2.x and 3.