### PR TITLE
Move development dependencies from gemspec to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 gemspec
+
+group :development do
+  gem 'pry'
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+end

--- a/forked.gemspec
+++ b/forked.gemspec
@@ -20,9 +20,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
Resolve [Gemspec/DevelopmentDependencies](https://www.rubydoc.info/gems/rubocop/1.56.3/RuboCop/Cop/Gemspec/DevelopmentDependencies).