### PR TITLE
 CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Ruby 3.3 has been released!

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

Let's test against it in the CI build to ensure compatibility.