### PR TITLE
Remove unneeded files from the gem package

### DIFF
--- a/forked.gemspec
+++ b/forked.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{}
   spec.homepage      = "https://github.com/envato/forked"
 
-  spec.files = Dir["lib/**/*.rb"]
-  spec.files += Dir['[A-Z]*']
+  spec.files = Dir["lib/**/*.rb"] + Dir["*.txt"] + Dir["*.md"]
   spec.require_paths = ['lib']
 
   spec.bindir        = "exe"


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Security scans can get caught up with the contents of the Gemfile.lock even though it is given no heed.

Let's remove these files:

```patch
< Gemfile
< Gemfile.lock
  LICENSE.txt
  README.md
< Rakefile
< forked.gemspec
  lib/forked.rb
  lib/forked/process_manager.rb
  lib/forked/retry_strategies/always.rb
  lib/forked/retry_strategies/exponential_backoff.rb
  lib/forked/retry_strategies/exponential_backoff_with_limit.rb
  lib/forked/version.rb
  lib/forked/with_graceful_shutdown.rb
  lib/forked/worker.rb
```